### PR TITLE
Fix Data Science benchmark import error

### DIFF
--- a/evaluation/benchmarks/data_science_bench/run_infer.py
+++ b/evaluation/benchmarks/data_science_bench/run_infer.py
@@ -15,7 +15,6 @@ from evaluation.utils.shared import (
     EvalMetadata,
     EvalOutput,
     codeact_user_response,
-    errorbench_user_response,
     get_default_sandbox_config_for_eval,
     make_metadata,
     reset_logger_for_multiprocessing,
@@ -40,7 +39,7 @@ from .benchmark_additions import kill_instance, safe_append
 
 AGENT_RESPONSE_HANDLERS = {
     'CodeActAgent': codeact_user_response,
-    'ErrorBench': partial(errorbench_user_response, encapsulate_solution=True),
+    'ErrorBench': partial(codeact_user_response, encapsulate_solution=True),
 }
 
 LOCAL_DATASET_PATH = os.path.join(os.path.dirname(__file__), 'benchmark')

--- a/evaluation/benchmarks/data_science_bench/run_infer_copy.py
+++ b/evaluation/benchmarks/data_science_bench/run_infer_copy.py
@@ -15,7 +15,6 @@ from evaluation.utils.shared import (
     EvalMetadata,
     EvalOutput,
     codeact_user_response,
-    errorbench_user_response,
     get_default_sandbox_config_for_eval,
     make_metadata,
     reset_logger_for_multiprocessing,
@@ -40,7 +39,7 @@ from openhands.utils.benchmark_additions import kill_instance, safe_append
 
 AGENT_CLS_TO_FAKE_USER_RESPONSE_FN = {
     'CodeActAgent': codeact_user_response,
-    'ErrorBench': partial(errorbench_user_response, encapsulate_solution=True),
+    'ErrorBench': partial(codeact_user_response, encapsulate_solution=True),
 }
 
 LOCAL_DATASET_PATH = os.path.join(os.path.dirname(__file__), 'benchmark')


### PR DESCRIPTION
## Summary
- update run_infer scripts for the data science benchmark
- use `codeact_user_response` handler directly

## Testing
- `python3 -m evaluation.benchmarks.data_science_bench.run_infer_copy` *(fails: ModuleNotFoundError: No module named 'hydra')*
- `python3 -m evaluation.benchmarks.data_science_bench.run_infer` *(fails: ModuleNotFoundError: No module named 'hydra')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openhands')*