### PR TITLE
Fix data science bench run_infer script

### DIFF
--- a/evaluation/benchmarks/data_science_bench/run_infer.py
+++ b/evaluation/benchmarks/data_science_bench/run_infer.py
@@ -423,10 +423,9 @@ def process_instance(
             config=config,
             initial_user_action=MessageAction(content=instruction),
             runtime=runtime,
-            fake_user_response_fn=AGENT_CLS_TO_FAKE_USER_RESPONSE_FN.get(
+            fake_user_response_fn=AGENT_RESPONSE_HANDLERS.get(
                 metadata.agent_class
             ),
-            cfg=cfg,
         )
     )
 


### PR DESCRIPTION
## Summary
- remove invalid `cfg` argument in `run_controller` call
- use `AGENT_RESPONSE_HANDLERS` when obtaining the fake user response

## Testing
- `pytest -q` *(fails: Docker not available)*