### PR TITLE
Fix feedback iteration limit handling

### DIFF
--- a/evaluation/benchmarks/data_science_bench/run_infer.py
+++ b/evaluation/benchmarks/data_science_bench/run_infer.py
@@ -511,6 +511,11 @@ def process_instance(
             output_command = runtime.run_action(
                 CmdRunAction(command='python3 /mnt/compute_metric.py')
             )
+            if (
+                isinstance(output_command, CmdOutputObservation)
+                and output_command.exit_code != 0
+            ):
+                state.last_error = output_command.content
             try:
                 tmp = float(output_command.content.split(':')[1])
                 scores.append(tmp)


### PR DESCRIPTION
## Summary
- ensure process_instance records errors from compute_metric

## Testing
- `pytest -k feedback_iteration_limit_end_to_end -q`

------
https://chatgpt.com/codex/tasks/task_e_683da94a84bc8324b8d446150ad9bf61